### PR TITLE
Fix Pawn/King bug

### DIFF
--- a/lib/chess_pieces/king.rb
+++ b/lib/chess_pieces/king.rb
@@ -5,6 +5,8 @@ require_relative 'chess_piece'
 ##
 # King piece for a gameof chess
 class King < ChessPiece
+  attr_writer :moved
+
   ##
   # Initializes a new king piece with color and position.
   #

--- a/lib/chess_pieces/pawn.rb
+++ b/lib/chess_pieces/pawn.rb
@@ -9,7 +9,8 @@ require_relative 'knight'
 ##
 # Pawn piece for a game of chess
 class Pawn < ChessPiece
-  attr_reader :move_count, :direction
+  attr_reader :direction
+  attr_accessor :move_count
 
   ##
   # Initializes a new pawn piece with color and position.
@@ -26,6 +27,14 @@ class Pawn < ChessPiece
   end
 
   ##
+  # Possible moves rewrite for the pawn
+  def possible_moves
+    # Remove the two space move on the Pawn's first move
+    @move_tree_template = @move_count.zero? ? build_pawn_move_tree_first_move : build_pawn_move_tree
+    super
+  end
+
+  ##
   # Moves the Pawn and updates @move_count
   # If the pawn reaches the back row of the opposing side, it returns a queen.
   #
@@ -34,9 +43,6 @@ class Pawn < ChessPiece
   # @return [Pawn or Queen] A pawn if the pawn moves or a Queen if the pawn
   #                         reaches the end of the board.
   def move(to)
-    # Remove the two space move on the Pawn's first move
-    @move_tree_template.root.children[0].children.pop if @move_count.zero?
-
     @move_count += 1
 
     if to[0] == @back_row
@@ -143,13 +149,32 @@ class Pawn < ChessPiece
   # diagonally to capture an enemy piece.
   #
   # @return [MoveTree] move_tree_template A move tree template for the pawn.
-  def build_pawn_move_tree
+  def build_pawn_move_tree_first_move
     move_tree = MoveTree.new([0, 0])
 
     # Create changes based on @direction because pawns can only move one
     # direction.
     move_tree.root.add_child([@direction, 0])
     move_tree.root.children[0].add_child([2 * @direction, 0])
+    move_tree.root.add_child([@direction, 1])
+    move_tree.root.add_child([@direction, -1])
+
+    move_tree
+  end
+
+  ##
+  # Builds the Pawn move tree without the two-space forward move.
+  # The pawn can move forward 2 spaces on its first move, but otherwise can
+  # only move one space forward. The Pawn may also move diagonally to capture
+  # an enemy piece.
+  #
+  # @return [MoveTree] move_tree_template A move tree template for the pawn.
+  def build_pawn_move_tree
+    move_tree = MoveTree.new([0, 0])
+
+    # Create changes based on @direction because pawns can only move one
+    # direction.
+    move_tree.root.add_child([@direction, 0])
     move_tree.root.add_child([@direction, 1])
     move_tree.root.add_child([@direction, -1])
 

--- a/spec/move_spec.rb
+++ b/spec/move_spec.rb
@@ -138,7 +138,6 @@ RSpec.describe 'ChessGame#make_move and its sub-methods' do
   end
 
   describe '#make_move' do
-
     it 'captures a pawn using En Passant' do
       # Set up the pawns on the board
       pawn = Pawn.new('white', [3, 3])
@@ -155,7 +154,9 @@ RSpec.describe 'ChessGame#make_move and its sub-methods' do
     end
 
     it 'updates the board locations' do
-      expect(proc { game.make_move([1, 1], [3, 1]) }).to change { board[1][1] }.to(ChessGame::BLANK_SQUARE).and change { board[3][1].is_a?(Pawn) }.to(true)
+      expect(proc { game.make_move([1, 1], [3, 1]) }).to change { board[1][1] }.to(ChessGame::BLANK_SQUARE).and change {
+                                                                                                                  board[3][1].is_a?(Pawn)
+                                                                                                                }.to(true)
     end
 
     it 'updates the king locations' do
@@ -165,7 +166,7 @@ RSpec.describe 'ChessGame#make_move and its sub-methods' do
         hash[piece.position] = piece
       end
       game.instance_variable_set(:@board, setup_board(current_board))
-      game.instance_variable_set(:@king_locs, { white:[3, 3], black:[6, 2]})
+      game.instance_variable_set(:@king_locs, { white: [3, 3], black: [6, 2] })
       king_locs = game.instance_variable_get(:@king_locs)
 
       expect(proc { game.make_move([3, 3], [3, 4]) }).to change { king_locs[:white] }.to([3, 4])


### PR DESCRIPTION
Fix a bug where ChessGame#forecast_move iterates pawn and king move counts without resetting, making opening moves and casting illegal even when it should be legal.